### PR TITLE
ci: update coverage to ignore empty files and non-runnable code

### DIFF
--- a/.coveragerc
+++ b/.coveragerc
@@ -1,0 +1,10 @@
+[report]
+exclude_lines =
+    # Have to re-enable the standard pragma
+    pragma: no cover
+
+    # Don't complain if non-runnable code isn't run:
+    if __name__ == .__main__.:
+
+omit = *\__init__.py
+        src\test\*


### PR DESCRIPTION
Ignore `__init__.py`
Ignore tests (`src/test/*`)
Ignore non-runnable code (specifically `if \__name__ == "__main__":`) SEE: https://coverage.readthedocs.io/en/latest/config.html sample configuration