### PR TITLE
Generate tiles from api

### DIFF
--- a/backend/src/main/flask/app.py
+++ b/backend/src/main/flask/app.py
@@ -1,6 +1,8 @@
 # pylint:disable=wrong-import-order,line-too-long
 import json
 
+from flask_cors import cross_origin
+
 from backend.src.main.game.dungeon.random_dungeon_generator import RandomDungeonGenerator
 from backend.src.main.serializer.dungeon_serializer import DungeonSerializer
 from backend.src.main.serializer.serializer_builder import SerializerBuilder
@@ -10,6 +12,7 @@ from flask import Flask
 
 class Handler:
     app = Flask(__name__)
+    app.config['CORS_HEADERS'] = 'Content-Type'
     EXPERIMENTAL = False
 
     @staticmethod
@@ -17,6 +20,7 @@ class Handler:
         return "Hello, world!"
 
     @staticmethod
+    @cross_origin(origin='localhost', headers=['Content- Type', 'Authorization'])
     def start():
         rdg = RandomDungeonGenerator(RandomWrapper())
         rdg.select_first_room()

--- a/backend/src/main/requirements.txt
+++ b/backend/src/main/requirements.txt
@@ -1,6 +1,8 @@
 Click==7.0
 Flask==1.1.1
+Flask-Cors==3.0.8
 itsdangerous==1.1.0
 Jinja2==2.10.3
 MarkupSafe==1.1.1
+six==1.14.0
 Werkzeug==0.16.0

--- a/web/app/package-lock.json
+++ b/web/app/package-lock.json
@@ -2183,6 +2183,37 @@
       "resolved": "https://registry.npmjs.org/aws4/-/aws4-1.9.1.tgz",
       "integrity": "sha512-wMHVg2EOHaMRxbzgFJ9gtjOOCrI80OHLG14rxi28XwOW8ux6IiEbRCGGGqCtdAIg4FQCbW20k9RsT4y3gJlFug=="
     },
+    "axios": {
+      "version": "0.19.2",
+      "resolved": "https://registry.npmjs.org/axios/-/axios-0.19.2.tgz",
+      "integrity": "sha512-fjgm5MvRHLhx+osE2xoekY70AhARk3a6hkN+3Io1jc00jtquGvxYlKlsFUhmUET0V5te6CcZI7lcv2Ym61mjHA==",
+      "requires": {
+        "follow-redirects": "1.5.10"
+      },
+      "dependencies": {
+        "debug": {
+          "version": "3.1.0",
+          "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
+          "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
+          "requires": {
+            "ms": "2.0.0"
+          }
+        },
+        "follow-redirects": {
+          "version": "1.5.10",
+          "resolved": "https://registry.npmjs.org/follow-redirects/-/follow-redirects-1.5.10.tgz",
+          "integrity": "sha512-0V5l4Cizzvqt5D44aTXbFZz+FtyXV1vrDN6qrelxtfYQKW0KO0W2T/hkE8xvGa/540LkZlkaUjO4ailYTFtHVQ==",
+          "requires": {
+            "debug": "=3.1.0"
+          }
+        },
+        "ms": {
+          "version": "2.0.0",
+          "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
+          "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+        }
+      }
+    },
     "axobject-query": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/axobject-query/-/axobject-query-2.1.1.tgz",
@@ -12847,6 +12878,14 @@
         "scheduler": "^0.18.0"
       }
     },
+    "react-editable-svg-label": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/react-editable-svg-label/-/react-editable-svg-label-2.0.3.tgz",
+      "integrity": "sha512-xpwqdQWOV6N9ZM2rJLPf1/hP6tz88SRhkOyaVRBV0Mh+RtqxN0K6cwtZk7Uvxh6PTtS9M8vDy8c/Ot0e9rPy4g==",
+      "requires": {
+        "prop-types": "^15.6.2"
+      }
+    },
     "react-error-overlay": {
       "version": "6.0.4",
       "resolved": "https://registry.npmjs.org/react-error-overlay/-/react-error-overlay-6.0.4.tgz",
@@ -12864,6 +12903,14 @@
       "version": "16.12.0",
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.12.0.tgz",
       "integrity": "sha512-rPCkf/mWBtKc97aLL9/txD8DZdemK0vkA3JMLShjlJB3Pj3s+lpf1KaBzMfQrAmhMQB0n1cU/SUGgKKBCe837Q=="
+    },
+    "react-portal": {
+      "version": "4.2.1",
+      "resolved": "https://registry.npmjs.org/react-portal/-/react-portal-4.2.1.tgz",
+      "integrity": "sha512-fE9kOBagwmTXZ3YGRYb4gcMy+kSA+yLO0xnPankjRlfBv4uCpFXqKPfkpsGQQR15wkZ9EssnvTOl1yMzbkxhPQ==",
+      "requires": {
+        "prop-types": "^15.5.8"
+      }
     },
     "react-prefixer": {
       "version": "2.0.1",

--- a/web/app/package.json
+++ b/web/app/package.json
@@ -6,10 +6,13 @@
     "@testing-library/jest-dom": "^4.2.4",
     "@testing-library/react": "^9.4.0",
     "@testing-library/user-event": "^7.2.1",
+    "axios": "^0.19.2",
     "react": "^16.12.0",
     "react-cards-stack": "^1.1.1",
     "react-dom": "^16.12.0",
+    "react-editable-svg-label": "^2.0.3",
     "react-hexgrid": "^1.0.3",
+    "react-portal": "^4.2.1",
     "react-prefixer": "^2.0.1",
     "react-scripts": "3.3.0"
   },

--- a/web/app/src/App.js
+++ b/web/app/src/App.js
@@ -10,13 +10,13 @@ class App extends Component {
         return (
             <div className="app">
                 <div>
-                    <button style={{display:"flex", float:"left"}} onClick={() => window.location.reload(false)}>Change Character</button>
+                    <button style={{display: "flex", float: "left"}}
+                            onClick={() => window.location.reload(false)}>Change Character
+                    </button>
                 </div>
                 <h1>Drag & drop</h1>
-                <HexGrid width={650} height={250} viewBox="-50 -50 100 100">
-                    <HexLayout/>
-                    <EntityLayout/>
-                </HexGrid>
+                {/*<HexLayout/>*/}
+                <EntityLayout/>
                 <PlayingCards abilityCards={this.props.abilityCards} characterName = {this.props.characterName}/>
             </div>
         );

--- a/web/app/src/Layout/EntityLayout.js
+++ b/web/app/src/Layout/EntityLayout.js
@@ -71,7 +71,6 @@ class EntityLayout extends Component {
 
         const hexagons2 = GridGenerator.hexagon(1);
 
-        // console.log(hexagons);
         this.state = {
             hexagons, hexagons2, isFetching: false,
             JSONdata: {
@@ -92,7 +91,6 @@ class EntityLayout extends Component {
         };
     }
 
-    // ---- //
     componentWillMount() {
         this.fetchHexagons();
     }
@@ -113,8 +111,6 @@ class EntityLayout extends Component {
         const data = this.state.JSONdata;
         const room1 = data[0].tiles;
         const tile_keys = Object.keys(room1);
-
-        // map function needs to somehow have a sense of what {hexagons} state is and append the newly generated hexagon
         return tile_keys.map(i =>
             this.generateHexagon(0, i)
         )
@@ -123,8 +119,8 @@ class EntityLayout extends Component {
     generateHexagon(roomID, tileID) {
         const tile = this.state.JSONdata[roomID].tiles[tileID];
         const tile_value = tile.value;
-        const image = this.state.image[tile_value]; // Didn't get set in <Hexagon>
-        const text = this.state.text[tile_value]; // Didn't get set in <Hexagon>
+        const image = this.state.image[tile_value];
+        const text = this.state.text[tile_value];
         const tile_key = "room-" + roomID + "-tile-" + tileID;
         const hex_data = {q: tile.x, r: tile.y, s: tile.z, text: {text}, image: {image}};
         const {hexagons2} = this.state.hexagons2;
@@ -149,8 +145,6 @@ class EntityLayout extends Component {
 
     }
 
-
-    // ---- //
 
     onDrop(event, source, targetProps) {
         const {hexagons} = this.state;

--- a/web/app/src/Layout/EntityLayout.js
+++ b/web/app/src/Layout/EntityLayout.js
@@ -38,7 +38,7 @@ class EntityLayout extends Component {
                 );
             }
         );
-        console.log(hexagons);
+        // console.log(hexagons);
         this.state = {hexagons};
     }
 
@@ -90,6 +90,7 @@ class EntityLayout extends Component {
 
     render() {
         const {hexagons} = this.state;
+        console.log(hexagons);
         return (
             <Layout className="tiles" size={{x: 10, y: 10}} flat={true} spacing={1.0} origin={{x: 60, y: -10}}>
                 {

--- a/web/app/src/Layout/EntityLayout.js
+++ b/web/app/src/Layout/EntityLayout.js
@@ -1,34 +1,64 @@
 import React, {Component} from 'react';
-import {GridGenerator, Layout, Hexagon, Text, Pattern, HexUtils} from 'react-hexgrid';
+import {GridGenerator, Layout, Hexagon, Text, Pattern, HexUtils, HexGrid} from 'react-hexgrid';
 import './EntityLayout.css';
+import axios from 'axios'
+
+const USER_SERVICE_URL = 'http://0.0.0.0:5000/start';
+
+const text = {
+    character: "Character",
+    monster: "Monster",
+    wall: "Wall",
+    obstacle: "Obstacle",
+    trap: "Trap",
+    empty: "Empty",
+    hazard: "Hazardous Terrain",
+    dangerous: "Dangerous Terrain",
+    entrance_a: "Entry A",
+    entrance_b: "Entry B",
+    "exit a": "Exit A",
+    "exit b": "Exit B",
+    coin: "Coin"
+
+};
+const image = {
+    character: "https://img.icons8.com/color/96/000000/morty-smith.png",
+    monster: "https://img.icons8.com/color/96/000000/monster-face.png",
+    wall: "https://img.icons8.com/color/96/000000/brick-wall.png",
+    obstacle: "https://img.icons8.com/color/96/000000/roadblock.png",
+    trap: "https://img.icons8.com/color/96/000000/naval-mine.png",
+    empty: "",
+    hazard: "https://img.icons8.com/color/96/000000/self-destruct-button--v1.png",
+    dangerous: "https://img.icons8.com/color/96/000000/error.png"
+};
+
+const EntityEnum = Object.freeze({
+    character: "Character",
+    monster: "Monster",
+    wall: "Wall",
+    obstacle: "Obstacle",
+    trap: "Trap",
+    empty: "Empty",
+    hazard: "Hazardous Terrain",
+    dangerous: "Dangerous Terrain"
+});
+const EntityImageEnum = Object.freeze({
+    character: "https://img.icons8.com/color/96/000000/morty-smith.png",
+    monster: "https://img.icons8.com/color/96/000000/monster-face.png",
+    wall: "https://img.icons8.com/color/96/000000/brick-wall.png",
+    obstacle: "https://img.icons8.com/color/96/000000/roadblock.png",
+    trap: "https://img.icons8.com/color/96/000000/naval-mine.png",
+    empty: "",
+    hazard: "https://img.icons8.com/color/96/000000/self-destruct-button--v1.png",
+    dangerous: "https://img.icons8.com/color/96/000000/error.png"
+});
+
+var name_values = Object.values(EntityEnum);
+var image_values = Object.values(EntityImageEnum);
 
 class EntityLayout extends Component {
     constructor(props) {
         super(props);
-
-        const EntityEnum = Object.freeze({
-            character: "Character",
-            monster: "Monster",
-            wall: "Wall",
-            obstacle: "Obstacle",
-            trap: "Trap",
-            empty: "Empty",
-            hazard: "Hazardous Terrain",
-            dangerous: "Dangerous Terrain"
-        });
-        const EntityImageEnum = Object.freeze({
-            character: "https://img.icons8.com/color/96/000000/morty-smith.png",
-            monster: "https://img.icons8.com/color/96/000000/monster-face.png",
-            wall: "https://img.icons8.com/color/96/000000/brick-wall.png",
-            obstacle: "https://img.icons8.com/color/96/000000/roadblock.png",
-            trap: "https://img.icons8.com/color/96/000000/naval-mine.png",
-            empty: "",
-            hazard: "https://img.icons8.com/color/96/000000/self-destruct-button--v1.png",
-            dangerous: "https://img.icons8.com/color/96/000000/error.png"
-        });
-
-        var name_values = Object.values(EntityEnum);
-        var image_values = Object.values(EntityImageEnum);
 
         const hexagons = GridGenerator.parallelogram(-1, 0, -1, 2).map((hexagon, index) => {
                 return Object.assign({}, hexagon, {
@@ -38,9 +68,89 @@ class EntityLayout extends Component {
                 );
             }
         );
+
+        const hexagons2 = GridGenerator.hexagon(1);
+
         // console.log(hexagons);
-        this.state = {hexagons};
+        this.state = {
+            hexagons, hexagons2, isFetching: false,
+            JSONdata: {
+                "0": {
+                    "name": "Den",
+                    "tiles": {
+                        "0": {
+                            "x": 0,
+                            "y": 0,
+                            "z": 0,
+                            "value": "monster"
+                        },
+                    }
+                }
+            },
+            image: image,
+            text: text
+        };
     }
+
+    // ---- //
+    componentWillMount() {
+        this.fetchHexagons();
+    }
+
+    fetchHexagons() {
+        this.setState({...this.state, isFetching: true});
+        axios.get(USER_SERVICE_URL)
+            .then(response => {
+                this.setState({JSONdata: response.data, isFetching: false})
+                // console.log("First room = " + response.data[0].name)
+            })
+            .catch(e => {
+                this.setState({...this.state, isFetching: false});
+            });
+    }
+
+    parseHexagons() {
+        const data = this.state.JSONdata;
+        const room1 = data[0].tiles;
+        const tile_keys = Object.keys(room1);
+
+        // map function needs to somehow have a sense of what {hexagons} state is and append the newly generated hexagon
+        return tile_keys.map(i =>
+            this.generateHexagon(0, i)
+        )
+    }
+
+    generateHexagon(roomID, tileID) {
+        const tile = this.state.JSONdata[roomID].tiles[tileID];
+        const tile_value = tile.value;
+        const image = this.state.image[tile_value]; // Didn't get set in <Hexagon>
+        const text = this.state.text[tile_value]; // Didn't get set in <Hexagon>
+        const tile_key = "room-" + roomID + "-tile-" + tileID;
+        const hex_data = {q: tile.x, r: tile.y, s: tile.z, text: {text}, image: {image}};
+        const {hexagons2} = this.state.hexagons2;
+
+        return <Hexagon
+            key={tileID}
+            q={tile.x}
+            r={tile.y}
+            s={tile.z}
+            fill={tileID}
+            image={this.state.image[tile_value]}
+            text={this.state.text[tile_value]}
+            data={hex_data}
+            onDragStart={(e, h) => this.onDragStart(e, h)}
+            onDragEnd={(e, h, s) => this.onDragEnd(e, h, s)}
+            onDrop={(e, h, t) => this.onDrop(e, h, t)}
+            onDragOver={(e, h) => this.onDragOver(e, h)}
+        >
+            <Text>{text}</Text>
+            <Pattern id={tileID} link={image} size={{x: 5, y: 5}}/>
+        </Hexagon>
+
+    }
+
+
+    // ---- //
 
     onDrop(event, source, targetProps) {
         const {hexagons} = this.state;
@@ -65,8 +175,9 @@ class EntityLayout extends Component {
         const blocked = blockedHexes.find(blockedHex => {
             return HexUtils.equals(source.state.hex, blockedHex);
         });
+        console.log(source.props);
+        const {text} = source.props;
 
-        const {text} = source.props.data;
         if (!blocked && !text) {
             event.preventDefault();
         }
@@ -90,29 +201,37 @@ class EntityLayout extends Component {
 
     render() {
         const {hexagons} = this.state;
-        console.log(hexagons);
+        const gameHexes = this.parseHexagons();
+        // map function needs to somehow have a sense of what {hexagons} state is and append the newly generated hexagon
         return (
-            <Layout className="tiles" size={{x: 10, y: 10}} flat={true} spacing={1.0} origin={{x: 60, y: -10}}>
-                {
-                    hexagons.map((hex, i) => (
-                        <Hexagon
-                            key={i}
-                            q={hex.q}
-                            r={hex.r}
-                            s={hex.s}
-                            fill={(hex.image) ? HexUtils.getID(hex) : null}
-                            data={hex}
-                            onDragStart={(e, h) => this.onDragStart(e, h)}
-                            onDragEnd={(e, h, s) => this.onDragEnd(e, h, s)}
-                            onDrop={(e, h, t) => this.onDrop(e, h, t)}
-                            onDragOver={(e, h) => this.onDragOver(e, h)}
-                        >
-                            <Text>{hex.text}</Text>
-                            {hex.image && <Pattern id={HexUtils.getID(hex)} link={hex.image}/>}
-                        </Hexagon>
-                    ))
-                }
-            </Layout>
+            <HexGrid width={1300} height={500} viewBox="-50 -50 100 100">
+                <Layout className="game" size={{x: 5, y: 5}} flat={true} spacing={1.0} origin={{x: -30, y: 0}}>
+                    {
+                        gameHexes
+                    }
+                </Layout>
+                <Layout className="tiles" size={{x: 10, y: 10}} flat={true} spacing={1.0} origin={{x: 60, y: -10}}>
+                    {
+                        hexagons.map((hex, i) => (
+                            <Hexagon
+                                key={i}
+                                q={hex.q}
+                                r={hex.r}
+                                s={hex.s}
+                                fill={(hex.image) ? HexUtils.getID(hex) : null}
+                                data={hex}
+                                onDragStart={(e, h) => this.onDragStart(e, h)}
+                                onDragEnd={(e, h, s) => this.onDragEnd(e, h, s)}
+                                onDrop={(e, h, t) => this.onDrop(e, h, t)}
+                                onDragOver={(e, h) => this.onDragOver(e, h)}
+                            >
+                                <Text>{hex.text}</Text>
+                                {hex.image && <Pattern id={HexUtils.getID(hex)} link={hex.image}/>}
+                            </Hexagon>
+                        ))
+                    }
+                </Layout>
+            </HexGrid>
         );
     }
 }

--- a/web/app/src/Layout/EntityLayout.js
+++ b/web/app/src/Layout/EntityLayout.js
@@ -38,6 +38,7 @@ class EntityLayout extends Component {
                 );
             }
         );
+        console.log(hexagons);
         this.state = {hexagons};
     }
 

--- a/web/app/src/Layout/HexLayout.css
+++ b/web/app/src/Layout/HexLayout.css
@@ -24,7 +24,7 @@ svg .game g polygon {
 }
 
 svg .game g text {
-    font-size: 0.22em;
+    font-size: 0.11em;
     fill: white;
     fill-opacity: 0.7;
     transition: fill-opacity .5s;

--- a/web/app/src/Layout/HexLayout.js
+++ b/web/app/src/Layout/HexLayout.js
@@ -7,6 +7,8 @@ const USER_SERVICE_URL = 'http://0.0.0.0:5000/start';
 
 class HexLayout extends Component {
     constructor(props) {
+        super(props);
+
         const text = {
             character: "Character",
             monster: "Monster",
@@ -34,10 +36,17 @@ class HexLayout extends Component {
             dangerous: "https://img.icons8.com/color/96/000000/error.png"
         };
 
-        super(props);
-        const hexagons = GridGenerator.hexagon(1);
-        this.state = {hexagons};
+
+        const hexagons = GridGenerator.parallelogram(-1, 0, -1, 2).map((hexagon, index) => {
+                return Object.assign({}, hexagon, {
+                        text: text[index],
+                        image: image[index]
+                    }
+                );
+            }
+        );
         this.state = {
+            hexagons,
             isFetching: false,
             data: {
                 "0": {
@@ -90,10 +99,7 @@ class HexLayout extends Component {
     }
 
     onDragOver(event, source) {
-        const {text} = source.props.data.text;
-        if (!text) {
-            event.preventDefault();
-        }
+        event.preventDefault();
     }
 
     onDragEnd(event, source, success) {
@@ -101,7 +107,7 @@ class HexLayout extends Component {
             return;
         }
 
-        const {hexagons} = this.state;
+        const {hexagons} = this.state.hexagons;
         const hexes = hexagons.map(hex => {
             if (HexUtils.equals(source.state.hex, hex)) {
                 hex.text = null;
@@ -118,20 +124,21 @@ class HexLayout extends Component {
         const tile_keys = Object.keys(room1);
 
         // map function needs to somehow have a sense of what {hexagons} state is and append the newly generated hexagon
-        return tile_keys.map(tileID =>
-            this.generateHexagon(0, tileID)
+        return tile_keys.map(i =>
+            this.generateHexagon(0, i)
         )
     }
 
-    generateHexagon(roomID, tileID, q, r, s) {
+    generateHexagon(roomID, tileID) {
         const tile = this.state.data[roomID].tiles[tileID];
         const tile_value = tile.value;
         const image = this.state.image[tile_value]; // Didn't get set in <Hexagon>
         const text = this.state.text[tile_value]; // Didn't get set in <Hexagon>
         const tile_key = "room-" + roomID + "-tile-" + tileID;
 
+        const {hexagons} = this.state.hexagons;
+
         return <Hexagon
-            key={tileID} // Changed to tileID from tile_key
             q={tile.x}
             r={tile.y}
             s={tile.z}

--- a/web/app/src/Layout/HexLayout.js
+++ b/web/app/src/Layout/HexLayout.js
@@ -7,16 +7,57 @@ const USER_SERVICE_URL = 'http://0.0.0.0:5000/start';
 
 class HexLayout extends Component {
     constructor(props) {
+        const text = {
+            character: "Character",
+            monster: "Monster",
+            wall: "Wall",
+            obstacle: "Obstacle",
+            trap: "Trap",
+            empty: "Empty",
+            hazard: "Hazardous Terrain",
+            dangerous: "Dangerous Terrain",
+            entrance_a: "Entry A",
+            entrance_b: "Entry B",
+            "exit a": "Exit A",
+            "exit b": "Exit B",
+            coin: "Coin"
+
+        };
+        const image = {
+            character: "https://img.icons8.com/color/96/000000/morty-smith.png",
+            monster: "https://img.icons8.com/color/96/000000/monster-face.png",
+            wall: "https://img.icons8.com/color/96/000000/brick-wall.png",
+            obstacle: "https://img.icons8.com/color/96/000000/roadblock.png",
+            trap: "https://img.icons8.com/color/96/000000/naval-mine.png",
+            empty: "",
+            hazard: "https://img.icons8.com/color/96/000000/self-destruct-button--v1.png",
+            dangerous: "https://img.icons8.com/color/96/000000/error.png"
+        };
+
         super(props);
-        const hexagons = GridGenerator.hexagon(0);
-        // this.state = {hexagons};
+        const hexagons = GridGenerator.hexagon(1);
+        this.state = {hexagons};
         this.state = {
             isFetching: false,
-            hexagons: []
+            data: {
+                "0": {
+                    "name": "Den",
+                    "tiles": {
+                        "0": {
+                            "x": 0,
+                            "y": 0,
+                            "z": 0,
+                            "value": "monster"
+                        },
+                    }
+                }
+            },
+            image: image,
+            text: text
         };
     }
 
-    componentDidMount() {
+    componentWillMount() {
         this.fetchHexagons();
     }
 
@@ -26,6 +67,7 @@ class HexLayout extends Component {
             .then(response => {
                 this.setState({data: response.data, isFetching: false})
                 console.log(response.data);
+                // console.log("First room = " + response.data[0].name)
             })
             .catch(e => {
                 this.setState({...this.state, isFetching: false});
@@ -78,29 +120,49 @@ class HexLayout extends Component {
         this.setState({hexagons: hexes});
     }
 
+    parseHexagons() {
+        const data = this.state.data;
+        const room1 = data[0].tiles;
+        const tile_keys = Object.keys(room1);
+
+        return tile_keys.map(tileID =>
+            this.generateHexagon(0, tileID)
+        )
+    }
+
+    generateHexagon(roomID, tileID, q, r, s) {
+        const tile = this.state.data[roomID].tiles[tileID];
+        const tile_value = tile.value;
+        const image = this.state.image[tile_value];
+        const text = this.state.text[tile_value];
+        const tile_key = "room-" + roomID + "-tile-" + tileID;
+        console.log(image);
+        console.log(tile_value);
+        return <Hexagon
+            key={tile_key}
+            q={tile.x}
+            r={tile.y}
+            s={tile.z}
+            fill={"pat-" + tile_key}
+            image={image}
+            text={text}
+            onDragStart={(e, h) => this.onDragStart(e, h)}
+            onDragEnd={(e, h, s) => this.onDragEnd(e, h, s)}
+            onDrop={(e, h, t) => this.onDrop(e, h, t)}
+            onDragOver={(e, h) => this.onDragOver(e, h)}
+        >
+            <Text>{text}</Text>
+            <Pattern id={"pat-" + tile_key} link={image} size={{x: 5, y: 5}}/>
+
+        </Hexagon>
+    }
+
     render() {
-        let {hexagons} = this.state;
+        console.log(this.state.image.character);
+        const hexagons = this.parseHexagons();
         return (
-            <Layout className="game" size={{x: 10, y: 10}} flat={true} spacing={1.08} origin={{x: -30, y: 0}}>
-                {
-                    hexagons.map((hex, i) => (
-                        <Hexagon
-                            key={i}
-                            q={hex.q}
-                            r={hex.r}
-                            s={hex.s}
-                            fill={(hex.image) ? HexUtils.getID(hex) : null}
-                            data={hex}
-                            onDragStart={(e, h) => this.onDragStart(e, h)}
-                            onDragEnd={(e, h, s) => this.onDragEnd(e, h, s)}
-                            onDrop={(e, h, t) => this.onDrop(e, h, t)}
-                            onDragOver={(e, h) => this.onDragOver(e, h)}
-                        >
-                            <Text>{hex.text}</Text>
-                            {hex.image && <Pattern id={HexUtils.getID(hex)} link={hex.image}/>}
-                        </Hexagon>
-                    ))
-                }
+            <Layout className="game" size={{x: 5, y: 5}} flat={true} spacing={1.08} origin={{x: -30, y: 0}}>
+                {hexagons}
             </Layout>
         );
     }

--- a/web/app/src/Layout/HexLayout.js
+++ b/web/app/src/Layout/HexLayout.js
@@ -66,7 +66,6 @@ class HexLayout extends Component {
         axios.get(USER_SERVICE_URL)
             .then(response => {
                 this.setState({data: response.data, isFetching: false})
-                console.log(response.data);
                 // console.log("First room = " + response.data[0].name)
             })
             .catch(e => {
@@ -87,19 +86,12 @@ class HexLayout extends Component {
     }
 
     onDragStart(event, source) {
-        if (!source.props.data.text) {
-            event.preventDefault();
-        }
+        event.preventDefault();
     }
 
     onDragOver(event, source) {
-        const blockedHexes = this.state.hexagons.filter(h => h.blocked);
-        const blocked = blockedHexes.find(blockedHex => {
-            return HexUtils.equals(source.state.hex, blockedHex);
-        });
-
-        const {text} = source.props.data;
-        if (!blocked && !text) {
+        const {text} = source.props.data.text;
+        if (!text) {
             event.preventDefault();
         }
     }
@@ -125,6 +117,7 @@ class HexLayout extends Component {
         const room1 = data[0].tiles;
         const tile_keys = Object.keys(room1);
 
+        // map function needs to somehow have a sense of what {hexagons} state is and append the newly generated hexagon
         return tile_keys.map(tileID =>
             this.generateHexagon(0, tileID)
         )
@@ -133,33 +126,33 @@ class HexLayout extends Component {
     generateHexagon(roomID, tileID, q, r, s) {
         const tile = this.state.data[roomID].tiles[tileID];
         const tile_value = tile.value;
-        const image = this.state.image[tile_value];
-        const text = this.state.text[tile_value];
+        const image = this.state.image[tile_value]; // Didn't get set in <Hexagon>
+        const text = this.state.text[tile_value]; // Didn't get set in <Hexagon>
         const tile_key = "room-" + roomID + "-tile-" + tileID;
-        console.log(image);
-        console.log(tile_value);
+
         return <Hexagon
-            key={tile_key}
+            key={tileID} // Changed to tileID from tile_key
             q={tile.x}
             r={tile.y}
             s={tile.z}
-            fill={"pat-" + tile_key}
-            image={image}
-            text={text}
+            fill={tileID}
+            image={this.state.image[tile_value]}
+            text={this.state.text[tile_value]}
             onDragStart={(e, h) => this.onDragStart(e, h)}
             onDragEnd={(e, h, s) => this.onDragEnd(e, h, s)}
             onDrop={(e, h, t) => this.onDrop(e, h, t)}
             onDragOver={(e, h) => this.onDragOver(e, h)}
         >
             <Text>{text}</Text>
-            <Pattern id={"pat-" + tile_key} link={image} size={{x: 5, y: 5}}/>
-
+            <Pattern id={tileID} link={this.state.image[tile_value]} size={{x: 5, y: 5}}/>
         </Hexagon>
+
     }
 
     render() {
-        console.log(this.state.image.character);
         const hexagons = this.parseHexagons();
+        // props: key is undefined because it's not mapped correctly?
+        console.log(hexagons);
         return (
             <Layout className="game" size={{x: 5, y: 5}} flat={true} spacing={1.08} origin={{x: -30, y: 0}}>
                 {hexagons}

--- a/web/app/src/Layout/HexLayout.js
+++ b/web/app/src/Layout/HexLayout.js
@@ -1,12 +1,35 @@
 import React, {Component} from 'react';
 import {GridGenerator, Layout, Hexagon, Text, Pattern, HexUtils} from 'react-hexgrid';
 import './HexLayout.css';
+import axios from 'axios'
+
+const USER_SERVICE_URL = 'http://0.0.0.0:5000/start';
 
 class HexLayout extends Component {
     constructor(props) {
         super(props);
-        const hexagons = GridGenerator.hexagon(2);
-        this.state = {hexagons};
+        const hexagons = GridGenerator.hexagon(0);
+        // this.state = {hexagons};
+        this.state = {
+            isFetching: false,
+            hexagons: []
+        };
+    }
+
+    componentDidMount() {
+        this.fetchHexagons();
+    }
+
+    fetchHexagons() {
+        this.setState({...this.state, isFetching: true});
+        axios.get(USER_SERVICE_URL)
+            .then(response => {
+                this.setState({data: response.data, isFetching: false})
+                console.log(response.data);
+            })
+            .catch(e => {
+                this.setState({...this.state, isFetching: false});
+            });
     }
 
     onDrop(event, source, targetProps) {


### PR DESCRIPTION
- [x] Hexes are rendered on HexLayout from API successfully
- [x] Props for each hex correspond correctly with `text` and `image` enums
- [x] `onDragStart()` and `DragOver()` works
- [x] Moved all hex rendering code to EntityLayout instead of co-ordinating between HexLayout and EntityLayout 
 
Issues: 
- `onDrop()` bombs, need to fix but the API and flask configs are good to merge